### PR TITLE
Legacy libwallaby

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 This repository contains development guides, installation documentation and notes for FrenchBakery's projects.
 
+Please note that we are in no way associated with KIPR or any associated organization and this repository is purely based on our experiences with using their soft- and hardware. 
+
 ## Table of Contents
 
  - KIPR Base Image Setup
    - [SSH user setup](kipr_base/ssh_user_setup.md)
  - Custom Image Setup
    - [RPiOS installation](custom_image/rpios_installation.md)
+   - [Installing libwallaby on RPiOS](custom_image/install_libwallaby_rpios.md)
    - [Installing libkipr on RPiOS](custom_image/install_libkipr_rpios.md)

--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ Please note that we are in no way associated with KIPR or any associated organiz
    - [RPiOS installation](custom_image/rpios_installation.md)
    - [Installing libwallaby on RPiOS](custom_image/install_libwallaby_rpios.md)
    - [Installing libkipr on RPiOS](custom_image/install_libkipr_rpios.md)
+   - [Installing BotUI on RPiOS](custom_image/install_botui_rpios.md)

--- a/custom_image/install_botui_rpios.md
+++ b/custom_image/install_botui_rpios.md
@@ -1,4 +1,4 @@
-# Installing BotUI on PRiOS
+# Installing BotUI on RPiOS
 
 This section will guide you through installing BotUI on a generic Raspberry Pi OS (Lite) installation.
 

--- a/custom_image/install_botui_rpios.md
+++ b/custom_image/install_botui_rpios.md
@@ -138,14 +138,23 @@ To get started, install all the dependencies:
 sudo apt install matchbox xorg x11-xserver-utils xinit ttf-mscorefonts-installer xwit
 ```
 
-Then add the following content to the ```/etc/X11/xinit/xinitrc``` file:
+Then open the ```/etc/X11/xinit/xinitrc``` file, comment out any existing, uncommented lines and add the following content at the end:
 
 ```bash
-#!/bin/sh
-
 # custom setup for single view application
-matchbox-window-manager #-use_titlebar no & # start matchbox window manager
-# botui
-
+matchbox-window-manager & #-use_titlebar no & # start matchbox window manager
+# start botui
+botui
 ```
+
+This will start BotUI whenever X is started (like with the ```startx``` command).
+
+We can also add that to our ```.profile``` to automatically start on the console on login:
+
+```bash
+# start the UI
+startx &
+```
+
+To start this automatically on boot, we have to enable auto login using ```sudo raspi-config``` (System Options->Bott/AutoLogin->ConsoleAutoLogin).
 

--- a/custom_image/install_botui_rpios.md
+++ b/custom_image/install_botui_rpios.md
@@ -1,0 +1,151 @@
+# Installing BotUI on PRiOS
+
+This section will guide you through installing BotUI on a generic Raspberry Pi OS (Lite) installation.
+
+## Requirements
+
+ - A Wombat with a modern version of 32-Bit Raspberry Pi OS installed on the SD card (ideally [configured to work with the Wombat screen](rpios_installation.md))
+ - Network and Internet access on the Wombat (e.g. using ethernet on the local network)
+ - git and CMake (install using ```sudo apt install git cmake```)
+ - [Legacy libwallaby](install_libwallaby_rpios.md) installed
+
+## Workspace setup 
+
+To get started, ssh into your Wombat and create/navigate to a folder you wish to use for installation. Then clone the [frenchbakery/botui](https://github.com/frenchbakery/botui) repository because it has some patches that allow compilation using a modern compiler (more on that below):
+
+```bash
+mkdir -p kipr_installs
+cd kipr_installs
+git clone https://github.com/frenchbakery/botui
+cd botui
+```
+
+Recent versions of RPiOS don't support Qt4 anymore, so we have to use Qt5. 
+
+At the time of writing, the master branch doesn't quite support Qt5 jet and wouldn't compile with a modern compiler, so you will have to use the qt5-modern-compatability branch ([commit db5733e9dba82749a28b41f17b7f753d4d87aa0f](https://github.com/frenchbakery/botui/commit/db5733e9dba82749a28b41f17b7f753d4d87aa0f) at the time of writing):
+
+```bash
+git switch qt5-modern-compatability
+git pull
+```
+
+## Dependencies
+
+Before you can build the library, you need to install some dependencies. These are not documented on the official repository README.md jet. We need a feq Qt5 packages as well as OpenSSL:
+
+```bash
+sudo apt install libssl-dev qttools5-dev qtbase5-dev
+# you may also need these packages as well if CMake tells you (not quite sure if these are necessary for the qt5-fixed branch)
+sudo apt install qtdeclarative5-dev qtquickcontrols2-5-dev
+```
+
+BotUI also needs a few other KIPR libraries and programs that need to be installed manually in the following order.
+
+### libkar
+
+libkar needs Qt5 base which is already installed from before. To install it, simply clone the repository and use the master branch ([commit 8731c42116f784b39e84650c898d69e66c1711fc](https://github.com/kipr/libkar/commit/8731c42116f784b39e84650c898d69e66c1711fc) at the time of writing).
+
+```bash
+cd kipr_installs
+git clone https://github.com/kipr/libkar
+cd libkar
+```
+
+Create a build directory, initialize cmake, run make and and make install.
+
+```bash
+mkdir build
+cd build
+cmake ..
+make
+sudo make install
+```
+
+### pcompiler
+
+pcompiler also depends on Qt5 base as well as on libkar, so it needs to be installed after libkar. Thi installation itself is quite similar.
+
+Clone the reqpository and use the master branch ([commit e78d6197075870adb16475933985bdf9f23f33fb](https://github.com/kipr/pcompiler/commit/e78d6197075870adb16475933985bdf9f23f33fb) at the time of writing).
+
+```bash
+cd kipr_installs
+git clone https://github.com/kipr/pcompiler
+cd pcompiler
+```
+
+Create a build directory, initialize cmake, run make and and make install.
+
+```bash
+mkdir build
+cd build
+cmake ..
+make
+sudo make install
+```
+
+
+## Compiling
+
+In modern versions of GCC, apparently the vtable creation has changed, as there are several missing vtable errors when compiling the KIPR code. Therefore, we have created a patch, that adds dummy functions or virtual specifiers to generate these vtables. vtable explaination: https://stackoverflow.com/questions/3065154/undefined-reference-to-vtable
+
+Now we can compile the project as normal. Create a build directory, generate the build files using CMake and start the build using make:
+
+```bash
+mkdir build
+cd build
+cmake ..
+make
+```
+
+This takes a few minutes and may occasionally spit out some warnings about deprecated Qt functions but that shouldn't be an issue. It should exit with no errors.
+
+## Installation
+
+The binary and headers have now been prepared, however they still have to be copied to the correct system locations.
+
+To install BotUI you simply need to run the install target with root privileges.
+
+```bash
+# we are still in the build folder: libwallaby/build
+sudo make install
+```
+
+Now, botui can be started from anywhere using the ```botui``` command. However, this will probably fail because it will not find the pcompiler shared object. We have to create a link in ```/usr/lib`` for it to be found:
+
+```bash
+sudo ln -s /usr/local/lib/libpcompiler.so /usr/lib/libpcompiler.so
+```
+
+## Custom display setup
+
+If you are using Raspberry Pi OS Lite, you will probably encounter the following error:
+
+```
+qt.qpa.xcb: could not connect to display 
+qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
+This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
+
+Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, xcb.
+
+Aborted
+```
+
+This is because there is no display server and window manager running on the Pi. We will install the X11 display server with the simple matchbox window manager in this example. The matchbox window manager does only support one window at a time and is therefor ideal for kiosk applications like this one.
+
+To get started, install all the dependencies:
+
+```bash
+sudo apt install matchbox xorg x11-xserver-utils xinit ttf-mscorefonts-installer xwit
+```
+
+Then add the following content to the ```/etc/X11/xinit/xinitrc``` file:
+
+```bash
+#!/bin/sh
+
+# custom setup for single view application
+matchbox-window-manager #-use_titlebar no & # start matchbox window manager
+# botui
+
+```
+

--- a/custom_image/install_libkipr_rpios.md
+++ b/custom_image/install_libkipr_rpios.md
@@ -1,10 +1,10 @@
 # Installing libkipr on RPiOS
 
-This section will guide you through installing libkipr (the new version of libwallaby) on a generic Raspberry Pi OS (Lite) installation.
+This section will guide you through installing libkipr (the new version of libwallaby) on a generic Raspberry Pi OS (Lite) installation. This for sure works on 64-Bit versions of RPiOS, we haven't tested 32-Bit jet.
 
 ## Requirements
 
- - A Wombat with a modern version of Raspberry Pi OS installed on the SD card (ideally [configured to work with the Wombat screen](rpios_installation.md))
+ - A Wombat with a modern version of Raspberry Pi OS (64-Bit) installed on the SD card (ideally [configured to work with the Wombat screen](rpios_installation.md))
  - Network and Internet access on the Wombat (e.g. using ethernet on the local network)
 
 ## Compiling 

--- a/custom_image/install_libwallaby_rpios.md
+++ b/custom_image/install_libwallaby_rpios.md
@@ -1,0 +1,99 @@
+# Installing libwallaby on RPiOS
+
+This section will guide you through installing libwallaby (the older, and currently main version of the KIPR HAL library) on a generic Raspberry Pi OS (Lite) installation.
+
+## Requirements
+
+ - A Wombat with a modern version of 32-Bit Raspberry Pi OS installed on the SD card (ideally [configured to work with the Wombat screen](rpios_installation.md))
+ - Network and Internet access on the Wombat (e.g. using ethernet on the local network)
+ - git and CMake (install using ```sudo apt install git cmake```)
+
+## Workspace setup 
+
+To get started, ssh into your Wombat and create/navigate to a folder you wish to use for installation. Then clone the [kipr/libwallaby](https://github.com/kipr/libwallaby) or [frenchbakery/libkipr](https://github.com/frenchbakery/libkipr) repository:
+
+```bash
+mkdir -p kipr_installs
+cd kipr_installs
+git clone https://github.com/frenchbakery/libkipr
+cd libkipr
+```
+
+This library version is in the master branch ([commit 6cefbf2687b745b627588f5b713f358da711bb5b](https://github.com/frenchbakery/libkipr/commit/6cefbf2687b745b627588f5b713f358da711bb5b) at the time of writing)
+
+## Dependencies
+
+Unfortunately, this version of the source tree is intended for Raspbian Jessie and some things have changed since than. Therefore some dirty hacks have to be performed to be able to compile.
+
+First of all, make sure that the camera interface of the Raspberry Pi is enabled using ```sudo raspi-config```. We also need SPI (and possibly I2C) but those should already have been enabled during the [OS installation](rpios_installation.md). This step may require a reboot.
+
+After that is done, update the OS to install any new dependencies: 
+
+```bash
+sudo apt update
+sudo apt upgrade
+```
+
+Now we come to the dirty stuff. The CMake setup of libwallaby requires several Raspberry Pi specific libraries (shared objects) to be present under the ```/opt/vc/lib/``` folder. In recent OS versions, these have been moved to ```/usr/lib/arm-linux-gnueabihf/```. The ```/opt/``` directory is now empty. To fix this, we need to create a symbolic link to the new location so the build system can find the dependencies: 
+
+```bash
+sudo mkdir -p /opt/vc/lib
+sudo ln -s /usr/lib/arm-linux-gnueabihf /opt/vc/lib
+```
+
+Now we are almost ready. Before you can build the library, you need to install some dependencies. These are documented on the repository README.md.
+
+```bash
+sudo apt install libzbar-dev libopencv-dev libjpeg-dev python-dev doxygen swig
+```
+
+## Compiling
+
+At this point, you can simply follow the instructions found in the README.md that we have reworded below.
+
+Create a build directory, generate the build files using CMake and start the build using make:
+
+```bash
+mkdir build
+cd build
+cmake ..
+make
+```
+
+This takes a few minutes and may occasionally spit out some warnings but that shouldn't be an issue. It should exit with no errors.
+
+## Installation
+
+The binary and headers have now been prepared, however they still have to be copied to the correct system locations
+
+To install the library you simply need to run the install target with root privileges.
+
+```bash
+# we are still in the build folder: libwallaby/build
+sudo make install
+```
+
+## Compiling a programm
+
+This version of the library should be compatible header-wise with the one that comes with Wombat OS except for that it has more features and more headers. Standard stuff like motors, I/O, servos, ... should be identical:
+
+```cpp
+#include <kipr/servo.hpp>
+#include <kipr/motors.hpp>
+#include <kipr/digital.hpp>
+#include <kipr/util.hpp>
+```
+
+To link your code, instead of using the ```-lwallaby``` compiler flag like with the default library, you now need to specify the path to the library with your build sources. This is likely not a intended change, but rather something that I just can't figure out.
+
+If you wanted to compile the single-file project "main.cpp" to a "main" binary with the standard library on Wombat OS, you would need to do the following:
+
+```bash
+g++ -lwallaby -o main main.cpp
+```
+
+With the self-compiled library, the call would change to:
+
+```bash
+g++ -o main main.cpp /usr/lib/libkipr.so
+```

--- a/custom_image/install_libwallaby_rpios.md
+++ b/custom_image/install_libwallaby_rpios.md
@@ -64,7 +64,7 @@ This takes a few minutes and may occasionally spit out some warnings but that sh
 
 ## Installation
 
-The binary and headers have now been prepared, however they still have to be copied to the correct system locations
+The binary and headers have now been prepared, however they still have to be copied to the correct system locations.
 
 To install the library you simply need to run the install target with root privileges.
 

--- a/custom_image/install_libwallaby_rpios.md
+++ b/custom_image/install_libwallaby_rpios.md
@@ -23,7 +23,7 @@ This library version is in the master branch ([commit 6cefbf2687b745b627588f5b71
 
 ## Dependencies
 
-Unfortunately, this version of the source tree is intended for Raspbian Jessie and some things have changed since than. Therefore some dirty hacks have to be performed to be able to compile.
+Unfortunately, this version of the source tree is intended for Raspbian Jessie and some things have changed since then. Therefore some dirty hacks have to be performed to be able to compile.
 
 First of all, make sure that the camera interface of the Raspberry Pi is enabled using ```sudo raspi-config```. We also need SPI (and possibly I2C) but those should already have been enabled during the [OS installation](rpios_installation.md). This step may require a reboot.
 

--- a/custom_image/rpios_installation.md
+++ b/custom_image/rpios_installation.md
@@ -29,13 +29,6 @@ Once the Image is flashed, don't put it in the Wombat straight away, because the
 In the config.txt file, find the following lines:
 
 ```ini
-# uncomment the following to adjust overscan. Use positive numbers if console
-# goes off screen, and negative if there is too much border
-#overscan_left=16
-#overscan_right=16
-#overscan_top=16
-#overscan_bottom=16
-
 # uncomment to force a console size. By default it will be display's size minus
 # overscan.
 #framebuffer_width=1280
@@ -47,18 +40,15 @@ In the config.txt file, find the following lines:
 # uncomment to force a specific HDMI mode (this will force VGA)
 #hdmi_group=1
 #hdmi_mode=1
+
+# uncomment to force a HDMI mode rather than DVI. This can make audio work in
+# DMT (computer monitor) modes
+#hdmi_drive=2
 ```
 
 Replace this block with the following text. This will configure the screen size and HDMI mode to properly output Video on the integrated display:
 
 ```ini
-# uncomment the following to adjust overscan. Use positive numbers if console
-# goes off screen, and negative if there is too much border
-overscan_left=-2
-overscan_right=2
-overscan_top=-2
-overscan_bottom=2
-
 # uncomment to force a console size. By default it will be display's size minus
 # overscan.
 framebuffer_width=800#1280
@@ -74,6 +64,11 @@ hdmi_group=2
 hdmi_mode=87
 hdmi_cvt=800 480 60 6 0 0 0
 hdmi_ignore_edid=0xa5000080
+
+# uncomment to force a HDMI mode rather than DVI. This can make audio work in
+# DMT (computer monitor) modes
+#hdmi_drive=2
+hdmi_drive=1
 ```
 
 ### Enabling interfaces

--- a/custom_image/rpios_installation.md
+++ b/custom_image/rpios_installation.md
@@ -8,9 +8,19 @@ This section will guide you through the process of installing a fresh and modern
  - A Computer with internet access and an SD slot/reader
  - Raspberry Pi Imager installed on the computer
 
+## OS Selection
+
+When creating a custom image, you can select any version of Raspberry Pi OS that suits your needs. However, there are a few limitations and recommendations.
+
+First of all, the official Wombat OS is based on a (very old) 32-Bit version of Raspberry Pi OS. In order to get all of the legacy KIPR Software to work without too much hacking around, you will have to use a 32-Bit version as well. It is to be noted that there are discussions about updating to a newer version in KIPR internally, however it looks like that is not going to happen any time soon. Still, some versions of the software (like the [refactored libkipr](install_libkipr_rpios.md) that unfortunately isn't default jet) do work on 64-Bit RPiOS. Whenever that is the case, it is noted in our guide pages.
+
+When it comes to Full vs. Desktop vs. Lite, we recommend going with the Lite version of Raspberry Pi OS as it drastically reduces the amount of bloat that is present on the system by default and you will probably never need. Any additional software (like a window manager and display server) can be selectively installed later in case you need them.
+
+This installation guide applies both to 32-Bit and 64-Bit versions of Raspberry Pi OS Lite, so it should be trivial to select what you need.
+
 ## Installing the OS
 
-First of all, use the Raspberry Pi Imager to install the desired image onto your SD card. For this guide, we will be using the 64-bit version of Raspberry Pi OS Lite. Before flashing the image, go to the settings and configure the default user, e.g. "access" with PWD "access".
+First of all, use the Raspberry Pi Imager to install the desired image onto your SD card.  Before flashing the image, go to the settings and configure the default user, e.g. "access" with PWD "access".
 
 Once the Image is flashed, don't put it in the Wombat straight away, because the screen doesn't work out of the box. To configure the screen, open the config.txt file on the boot partition. While doing so, we can also configure some other peripherals.
 


### PR DESCRIPTION
Adds documentation about
 - installing the current master version of libwallaby
 - installing BotUI on 32-Bit RPiOS (Lite)
 - installing and configuring 32-Bit RPiOS (Lite)
 - installing matchbox and xorg for simple UI